### PR TITLE
No longer fail on destroy if key manually removed

### DIFF
--- a/examples/etcd_test/main.tf
+++ b/examples/etcd_test/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     etcdv2 = {
       // Source code is github.com/retryW/terraform-provider-etcdv2
-      source = "github.com/retryW/etcdv2"
+      source = "retryW/etcdv2"
     }
   }
 }

--- a/examples/etcd_test/main.tf
+++ b/examples/etcd_test/main.tf
@@ -19,7 +19,7 @@ data "etcdv2_keyvalue" "foo" {
 
 // Create a resource (create a desired state resource)
 resource "etcdv2_keyvalue" "test_kv_resource" {
-  key   = "/root/cale/test_kv_resource"
+  key   = "/root/test/bar"
   value = "myfirstetcdkv"
 }
 

--- a/internal/provider/keyvalue_resource.go
+++ b/internal/provider/keyvalue_resource.go
@@ -25,7 +25,7 @@ func NewKeyValueResource() resource.Resource {
 
 // KeyValueResource defines the resource implementation.
 type KeyValueResource struct {
-	client clientv2.Client
+	client *clientv2.Client
 }
 
 // KeyValueResourceModel describes the resource data model.
@@ -67,7 +67,7 @@ func (r *KeyValueResource) Configure(ctx context.Context, req resource.Configure
 		return
 	}
 
-	client, ok := req.ProviderData.(clientv2.Client)
+	client, ok := req.ProviderData.(*clientv2.Client)
 
 	if !ok {
 		resp.Diagnostics.AddError(
@@ -93,7 +93,7 @@ func (r *KeyValueResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	// Retrieve KeyAPI from client.
-	kapi := clientv2.NewKeysAPI(r.client)
+	kapi := clientv2.NewKeysAPI(*r.client)
 
 	keyvalue, err := kapi.Create(context.Background(), data.Key.ValueString(), data.Value.ValueString())
 	if err != nil {
@@ -121,7 +121,7 @@ func (r *KeyValueResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 
 	// Retrieve KeyAPI from client.
-	kapi := clientv2.NewKeysAPI(r.client)
+	kapi := clientv2.NewKeysAPI(*r.client)
 
 	keyvalue, err := kapi.Get(context.Background(), data.Key.ValueString(), nil)
 	if err != nil {
@@ -153,7 +153,7 @@ func (r *KeyValueResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	// Retrieve KeyAPI from client.
-	kapi := clientv2.NewKeysAPI(r.client)
+	kapi := clientv2.NewKeysAPI(*r.client)
 
 	keyvalue, err := kapi.Set(context.Background(), data.Key.ValueString(), data.Value.ValueString(), nil)
 	if err != nil {
@@ -181,7 +181,7 @@ func (r *KeyValueResource) Delete(ctx context.Context, req resource.DeleteReques
 	}
 
 	// Retrieve KeyAPI from client.
-	kapi := clientv2.NewKeysAPI(r.client)
+	kapi := clientv2.NewKeysAPI(*r.client)
 
 	_, err := kapi.Delete(context.Background(), data.Key.ValueString(), nil)
 	if err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,7 +30,7 @@ func New(version string) func() provider.Provider {
 	}
 }
 
-// ScaffoldingProvider defines the provider implementation.
+// etcdv2Provider defines the provider implementation.
 type etcdv2Provider struct {
 	// version is set to the provider version on release, "dev" when the
 	// provider is built and ran locally, and "test" when running acceptance
@@ -66,7 +66,7 @@ func (p *etcdv2Provider) Schema(ctx context.Context, req provider.SchemaRequest,
 				Optional:            true,
 				Sensitive:           true,
 			},
-			"timeout": schema.Int64Attribute {
+			"timeout": schema.Int64Attribute{
 				MarkdownDescription: "Maximum header timeout",
 				Optional:            true,
 			},
@@ -117,7 +117,7 @@ func (p *etcdv2Provider) Configure(ctx context.Context, req provider.ConfigureRe
 		return
 	}
 	headerTimeout := time.Duration(timeoutSec) * time.Second
-	
+
 	if host == "" {
 		resp.Diagnostics.AddError(
 			"No host detected.",
@@ -162,8 +162,8 @@ func (p *etcdv2Provider) Configure(ctx context.Context, req provider.ConfigureRe
 		}
 	}
 
-	resp.DataSourceData = etcdClient
-	resp.ResourceData = etcdClient
+	resp.DataSourceData = &etcdClient
+	resp.ResourceData = &etcdClient
 
 	tflog.Info(ctx, "Configured etcd client", map[string]any{
 		"host":     host,


### PR DESCRIPTION
- Will no longer throw an error during a destroy operation if the key has already been removed manually.
- Correctly removes the state doing resource read if the key no longer exists
- Changed resource and data etcd clients to use pointers.